### PR TITLE
fix for getMCOwnerName

### DIFF
--- a/src/main/java/com/minehut/discordbot/util/Bot.java
+++ b/src/main/java/com/minehut/discordbot/util/Bot.java
@@ -84,7 +84,7 @@ public class Bot {
 
     public static String getMCOwnerName(String UUID) {
         try {
-            JSONArray json = URLJson.readJsonArrayFromUrl("https://api.mojang.com/user/profiles/" + UUID.replaceAll("-", "") + "/names");
+            JSONArray json = new URLJson("https://api.mojang.com/user/profiles/" + UUID.replaceAll("-", "") + "/names").getJsonArray();
             return json.getJSONObject(json.length() - 1).getString("name");
         } catch (Exception ex) {
             ex.printStackTrace();


### PR DESCRIPTION
This fixes the getMCOwnerName(String UUID) method in com.minehut.discordbot.util.Bot