### PR TITLE
invite filter bypass - fixed

### DIFF
--- a/src/main/java/com/minehut/discordbot/util/Chat.java
+++ b/src/main/java/com/minehut/discordbot/util/Chat.java
@@ -27,7 +27,7 @@ public class Chat {
     }
 
     public static boolean hasInvite(Message message) {
-        return Pattern.compile("(?:https?://)?discord(?:app\\.com/invite|\\.gg|\\.io)/(\\S+?)").matcher(message.getContentRaw()).find();
+        return Pattern.compile("(?:https?://)?discord(?:app\\.com/invite|\\.gg|\\.io)/(\\S+?)").matcher(message.getContentRaw().toLowerCase()).find();
     }
 
     public static boolean hasRegex(Pattern regex, String imput) {


### PR DESCRIPTION
basically if you made any char in discordapp.com or discord.gg uppercase it'll bypass